### PR TITLE
Enable message broker authentication with username and password 

### DIFF
--- a/common/docker/base-image/scripts/start-agent.sh
+++ b/common/docker/base-image/scripts/start-agent.sh
@@ -186,6 +186,18 @@ else
 	sed -i "s/^.*level.*=.*$/level=${LOG_LEVEL}/g" ${PCA_HOME}/logging.ini
 fi
 
+if [ -z "${MB_USERNAME}" ]; then
+	sed -i "s/MB-USERNAME/ /g" ${PCA_HOME}/agent.conf
+else
+	sed -i "s#MB-USERNAME#${MB_USERNAME}#g" ${PCA_HOME}/agent.conf
+fi
+
+if [ -z "${MB_PASSWORD}" ]; then
+	sed -i "s/MB-PASSWORD/ /g" ${PCA_HOME}/agent.conf
+else
+	sed -i "s#MB-PASSWORD#${MB_PASSWORD}#g" ${PCA_HOME}/agent.conf
+fi
+
 # Start cartridge agent
 cd ${PCA_HOME}/
 python agent.py > /tmp/agent.screen.log 2>&1 &

--- a/common/vm/puppet/manifests/nodes/base.pp
+++ b/common/vm/puppet/manifests/nodes/base.pp
@@ -28,6 +28,8 @@ node 'base' {
   $local_package_dir    = '/mnt/packs'
   $mb_ip                = 'localhost'
   $mb_port              = '1883'
+  $mb_username          = 'system'
+  $mb_password          = 'manager'
   $cep_urls             = "localhost:7711"
   $cep_username         = 'admin'
   $cep_password         = 'admin'

--- a/common/vm/puppet/modules/python_agent/templates/agent.conf.erb
+++ b/common/vm/puppet/modules/python_agent/templates/agent.conf.erb
@@ -15,6 +15,8 @@
 [agent]
 mb.ip                                 =<%= @mb_ip %>
 mb.port                               =<%= @mb_port %>
+mb.username                           =<%= @mb_username %>
+mb.password                           =<%= @mb_password %>
 listen.address                        =localhost
 thrift.receiver.urls                  =<%= @cep_urls %>
 thrift.server.admin.username          =<%= @cep_username %>


### PR DESCRIPTION
for PCA and AMQPConnector in Messaging. Tested with Apache ActiveMQ using SimpleAuthenticationPlugin. 

Modified the base docker image startup script and the Puppet scripts to handle message broker credentials.
